### PR TITLE
Error while installing a2lix/translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "jms/i18n-routing-bundle": "^2.0",
     "jms/translation-bundle": "^1.2",
     "knplabs/doctrine-behaviors": "^1.3",
-    "a2lix/translation-form-bundle": "2.*@dev",
+    "a2lix/translation-form-bundle": "2.*",
     "jms/di-extra-bundle": "^1.7",
     "stof/doctrine-extensions-bundle": "^1.2",
     "oneup/uploader-bundle": "~1.3",


### PR DESCRIPTION
The requested package a2lix/translation-form-bundle could not be found in any version, there may be a typo in the package name.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

<!--
- Fix composer install
-->
