### PR TITLE
Ensure that one to many entities are not removed in sonata admin

### DIFF
--- a/src/Cocorico/CoreBundle/Admin/BookingAdmin.php
+++ b/src/Cocorico/CoreBundle/Admin/BookingAdmin.php
@@ -481,6 +481,9 @@ class BookingAdmin extends Admin
                     'options',
                     'sonata_type_collection',
                     array(
+                        // IMPORTANT!: Disable this field otherwise if child form has all its fields disabled
+                        // then the child entities will be removed while saving
+                        'disabled' => true,
                         'type_options' => array(
                             'delete' => false,
                             'delete_options' => array(
@@ -497,6 +500,7 @@ class BookingAdmin extends Admin
                     array(
                         'edit' => 'inline',
                         'inline' => 'table',
+                        'delete' => 'false',
                     )
                 )
                 ->end();

--- a/src/Cocorico/MessageBundle/Admin/ThreadAdmin.php
+++ b/src/Cocorico/MessageBundle/Admin/ThreadAdmin.php
@@ -152,6 +152,9 @@ class ThreadAdmin extends Admin
                 'messages',
                 'sonata_type_collection',
                 array(
+                    // IMPORTANT!: Disable this field otherwise if child form has all its fields disabled
+                    // then the child entities will be removed while saving
+                    'disabled' => true,
                     'type_options' => array(
                         // Prevents the "Delete" option from being displayed
                         'delete' => false,

--- a/src/Cocorico/UserBundle/Admin/UserAdmin.php
+++ b/src/Cocorico/UserBundle/Admin/UserAdmin.php
@@ -289,6 +289,9 @@ class UserAdmin extends SonataUserAdmin
                 'addresses',
                 'sonata_type_collection',
                 array(
+                    // IMPORTANT!: Disable this field otherwise if child form has all its fields disabled
+                    // then the child entities will be removed while saving
+                    'disabled' => true,
                     'type_options' => array(
                         'delete' => false,
                         'delete_options' => array(
@@ -307,6 +310,7 @@ class UserAdmin extends SonataUserAdmin
                 array(
                     'edit' => 'inline',
                     'inline' => 'table',
+                    'delete' => 'false',
                 )
             )
             ->end();


### PR DESCRIPTION
Ensure that one to many entities are not removed in sonata admin through sonata_type_collection