### PR TITLE
Remove unneeded '}}' at the end of some meta titles

### DIFF
--- a/src/Cocorico/CoreBundle/Resources/views/Frontend/Booking/new.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Frontend/Booking/new.html.twig
@@ -15,7 +15,7 @@
 {% set booking_duration = booking.duration(endDayIncluded, timeUnit) %}
 
 {%- block meta_title -%}
-    {{ 'booking.new.meta_title'|trans({}, 'cocorico_meta') ~ " " ~ listing_translation.title ~ ", " ~ listing_location.city ~ " - " ~ booking.start|localizeddate('short', 'none', 'fr') ~ ", " ~ booking_duration|add_time_unit_text ~ " : "  ~ " - " ~ cocorico_site_name }} }}
+    {{ 'booking.new.meta_title'|trans({}, 'cocorico_meta') ~ " " ~ listing_translation.title ~ ", " ~ listing_location.city ~ " - " ~ booking.start|localizeddate('short', 'none', 'fr') ~ ", " ~ booking_duration|add_time_unit_text ~ " : "  ~ " - " ~ cocorico_site_name }}
 {%- endblock -%}
 
 {%- block meta_description -%}

--- a/src/Cocorico/CoreBundle/Resources/views/Frontend/Listing/show.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Frontend/Listing/show.html.twig
@@ -12,7 +12,7 @@
 {% set listing_user = listing.user %}
 
 {%- block meta_title -%}
-    {{ 'listing.show.meta_title'|trans({}, 'cocorico_meta') ~ " " ~ listing_translation.title ~ " - " ~ listing_location.city ~ " - " ~ listing.priceDecimal ~ " " ~ currencySymbol(currentCurrency) ~ "/" ~  0|add_time_unit_text ~ " - " ~ cocorico_site_name }} }}
+    {{ 'listing.show.meta_title'|trans({}, 'cocorico_meta') ~ " " ~ listing_translation.title ~ " - " ~ listing_location.city ~ " - " ~ listing.priceDecimal ~ " " ~ currencySymbol(currentCurrency) ~ "/" ~  0|add_time_unit_text ~ " - " ~ cocorico_site_name }}
 {%- endblock -%}
 
 {%- block meta_description -%}

--- a/src/Cocorico/UserBundle/Resources/views/Frontend/Profile/show.html.twig
+++ b/src/Cocorico/UserBundle/Resources/views/Frontend/Profile/show.html.twig
@@ -10,7 +10,7 @@
 
 
 {%- block meta_title -%}
-    {{ 'user.show.meta_title'|trans({}, 'cocorico_meta') ~ " "  ~ user.name ~ " - " ~ cocorico_site_name }} }}
+    {{ 'user.show.meta_title'|trans({}, 'cocorico_meta') ~ " "  ~ user.name ~ " - " ~ cocorico_site_name }}
 {%- endblock -%}
 
 {%- block meta_description -%}


### PR DESCRIPTION
Remove unneeded '}}' at the end of some meta titles