### PR TITLE
Fix user language code too short and update integration doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ app/DoctrineMigrations
 app/bootstrap.php.cache
 app/spool
 app/cache
+app/bootstrap.php.cache
 !app/cache/.gitkeep
 app/config/parameters.yml
 app/config/parameters_test.yml


### PR DESCRIPTION
~Fix user language code too short and update integration doc~

Adds `app/bootstrap.php.cache` to .gitignore