### PR TITLE
Update ListingNewType.php

### DIFF
--- a/src/Cocorico/CoreBundle/Form/Type/Frontend/ListingNewType.php
+++ b/src/Cocorico/CoreBundle/Form/Type/Frontend/ListingNewType.php
@@ -28,6 +28,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\Valid;
 
 /**
@@ -74,7 +75,14 @@ class ListingNewType extends AbstractType implements TranslationContainerInterfa
         foreach ($this->locales as $i => $locale) {
             $titles[$locale] = array(
                 'label' => 'listing.form.title',
-                'constraints' => array(new NotBlank()),
+                'constraints' => array(new NotBlank(),
+                                       new Length(
+                                           array(
+                                            'max' => 50,
+                                            'min' => 3,
+                                                )
+                                            ),
+                                       ),
                 'attr' => array(
                     'placeholder' => 'auto',
                 ),


### PR DESCRIPTION
 Add this to avoid the error : vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:107, PDOException(code: 22001): SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'title' at row 1

| Q             | A
| ------------- | ---
| Bug fix?      | [ ]
| New feature?  | [ ]
| Tests pass?   | [ ]
| Fixed issues  | #... <!-- number of issue if any -->
| License       | MIT

<!--
- Replace this comment by a description of what your PR is solving.
-->

## Checklist:

- [ ] Update [CHANGELOG.md](https://github.com/Cocolabs-SAS/cocorico/blob/master/CHANGELOG.md)