### PR TITLE
Update the documentation > PHP extension  : socket is needed

### DIFF
--- a/doc/installation-server-linux.md
+++ b/doc/installation-server-linux.md
@@ -54,6 +54,7 @@ Activate following extensions:
     - opcache
     - apcu
     - zip
+    - sockets
     
 Add the following lines to php.ini:
 


### PR DESCRIPTION
Updating the documentation:

The php extension `sockets` is needed for doing `composer install`